### PR TITLE
Parameterize roots when reading over module name and digest

### DIFF
--- a/src/docOck.mli
+++ b/src/docOck.mli
@@ -29,9 +29,9 @@ type 'a result =
   | Corrupted_interface
   | Not_a_typedtree
 
-val read_cmti: 'a -> string -> 'a result
+val read_cmti: (string -> Digest.t -> 'a) -> string -> 'a result
 
-val read_cmi: 'a -> string -> 'a result
+val read_cmi: (string -> Digest.t -> 'a) -> string -> 'a result
 
 type 'a resolver
 


### PR DESCRIPTION
This way, roots can stand-alone, we don't need to guess about their identity from file names, and we can confirm from read files that link time information still holds.